### PR TITLE
Update NoCaptcha.php

### DIFF
--- a/src/NoCaptcha.php
+++ b/src/NoCaptcha.php
@@ -342,7 +342,7 @@ class NoCaptcha implements Contracts\NoCaptcha
     private function renderCaptchas(array $captchas)
     {
         return implode(PHP_EOL, array_map(function($captcha) {
-            return "if(document.getElementById('".$captcha."')){ grecaptcha.render('{$captcha}', {'sitekey' : '{$this->siteKey}'}) };";
+            return "if(document.getElementById('".$captcha."')){ window.recaptcha_widget_{$captcha} = grecaptcha.render('{$captcha}', {'sitekey' : '{$this->siteKey}'}) };";
         }, $captchas));
     }
 

--- a/src/NoCaptcha.php
+++ b/src/NoCaptcha.php
@@ -342,7 +342,7 @@ class NoCaptcha implements Contracts\NoCaptcha
     private function renderCaptchas(array $captchas)
     {
         return implode(PHP_EOL, array_map(function($captcha) {
-            return "grecaptcha.render('{$captcha}', {'sitekey' : '{$this->siteKey}'});";
+            return "if(document.getElementById('".$captcha."')){ grecaptcha.render('{$captcha}', {'sitekey' : '{$this->siteKey}'}) };";
         }, $captchas));
     }
 


### PR DESCRIPTION
Check if element id exist in dom before render it

This is useful if you have a Captcha in the contact form page and a Captcha on the template's footer. 
Avoid a js error "_ReCAPTCHA placeholder element does not exist_" when one of the Captchas is not present in 
`{!! Captcha::scriptWithCallback(['captchas1', 'captchas2']); !!}`
